### PR TITLE
Long Indicator step + 2 minor fixes

### DIFF
--- a/ruler-picker/src/main/java/com/kevalpatel2106/rulerpicker/RulerValuePicker.java
+++ b/ruler-picker/src/main/java/com/kevalpatel2106/rulerpicker/RulerValuePicker.java
@@ -195,6 +195,12 @@ public final class RulerValuePicker extends FrameLayout implements ObservableHor
                     setMinMaxValue(a.getInteger(R.styleable.RulerValuePicker_min_value, 0),
                             a.getInteger(R.styleable.RulerValuePicker_max_value, 100));
                 }
+                if (a.hasValue(R.styleable.RulerValuePicker_long_indicator_step)){
+                    int mLongIndicatorStep = a.getInteger(R.styleable.RulerValuePicker_long_indicator_step, 5);
+                    if (mLongIndicatorStep < 1)
+                        mLongIndicatorStep = 5; /*Fallback to default to prevent unexpected behaviour*/
+                    setLongIndicatorStep(mLongIndicatorStep);
+                }
             } finally {
                 a.recycle();
             }
@@ -322,7 +328,7 @@ public final class RulerValuePicker extends FrameLayout implements ObservableHor
                 }
 
                 mHorizontalScrollView.smoothScrollTo(
-                        valuesToScroll * mRulerView.getIndicatorIntervalWidth(), 0);
+                        (valuesToScroll+1) * mRulerView.getIndicatorIntervalWidth(), 0);//extra 1 for spacing which we artificially added in case the labels may wanna get drawn
             }
         }, 400);
     }
@@ -332,7 +338,7 @@ public final class RulerValuePicker extends FrameLayout implements ObservableHor
      */
     public int getCurrentValue() {
         int absoluteValue = mHorizontalScrollView.getScrollX() / mRulerView.getIndicatorIntervalWidth();
-        int value = mRulerView.getMinValue() + absoluteValue;
+        int value = mRulerView.getMinValue() + absoluteValue - 1;//extra 1 for spacing which we artificially added in case the labels may wanna get drawn
 
         if (value > mRulerView.getMaxValue()) {
             return mRulerView.getMaxValue();
@@ -533,6 +539,26 @@ public final class RulerValuePicker extends FrameLayout implements ObservableHor
      */
     public void setIndicatorWidth(final int widthPx) {
         mRulerView.setIndicatorWidth(widthPx);
+    }
+
+    /**
+     * Set a step for a long indictor to be drawn.
+     * Every step a long indicator will be drawn.
+     * @param step - Step in decimal
+     * @see #getLongIndicatorStep()
+     * @see RulerView#mLongIndicatorStep
+     */
+    public void setLongIndicatorStep(final int step){
+        mRulerView.setLongIndicatorStep(step);
+    }
+
+    /**
+     * @return Long indicator step
+     * @see #setLongIndicatorStep(int)
+     * @see RulerView#mLongIndicatorStep
+     */
+    public int getLongIndicatorStep(){
+        return mRulerView.getLongIndicatorStep();
     }
 
     /**

--- a/ruler-picker/src/main/java/com/kevalpatel2106/rulerpicker/RulerValuePicker.java
+++ b/ruler-picker/src/main/java/com/kevalpatel2106/rulerpicker/RulerValuePicker.java
@@ -315,22 +315,39 @@ public final class RulerValuePicker extends FrameLayout implements ObservableHor
      *              will be selected.
      */
     public void selectValue(final int value) {
-        mHorizontalScrollView.postDelayed(new Runnable() {
-            @Override
-            public void run() {
-                int valuesToScroll;
-                if (value < mRulerView.getMinValue()) {
-                    valuesToScroll = 0;
-                } else if (value > mRulerView.getMaxValue()) {
-                    valuesToScroll = mRulerView.getMaxValue() - mRulerView.getMinValue();
-                } else {
-                    valuesToScroll = value - mRulerView.getMinValue();
-                }
+        selectValueDelayed(value, 0);
+    }
 
-                mHorizontalScrollView.smoothScrollTo(
-                        (valuesToScroll+1) * mRulerView.getIndicatorIntervalWidth(), 0);//extra 1 for spacing which we artificially added in case the labels may wanna get drawn
-            }
-        }, 400);
+    /**
+     * Scroll the ruler to the given value.
+     * If value isn't reached yet - loop with delay 3 times till we manage to set the value ASAP.
+     * @param value Value to select. Value must be between {@link #getMinValue()} and {@link #getMaxValue()}.
+     *              If the value is less than {@link #getMinValue()}, {@link #getMinValue()} will be
+     *              selected.If the value is greater than {@link #getMaxValue()}, {@link #getMaxValue()}
+     *              will be selected.
+     * @param iteration - initial call should pass 0, the rest are done internally
+     */
+    private void selectValueDelayed(final int value, final int iteration){
+        int valuesToScroll;
+        if (value < mRulerView.getMinValue()) {
+            valuesToScroll = 0;
+        } else if (value > mRulerView.getMaxValue()) {
+            valuesToScroll = mRulerView.getMaxValue() - mRulerView.getMinValue();
+        } else {
+            valuesToScroll = value - mRulerView.getMinValue();
+        }
+
+        mHorizontalScrollView.smoothScrollTo(
+                (valuesToScroll+1) * mRulerView.getIndicatorIntervalWidth(), 0);//extra 1 for spacing which we artificially added in case the labels may wanna get drawn
+
+        if (getCurrentValue() != value && iteration < 3) {//loop protection with iteration from infinity
+            mHorizontalScrollView.postDelayed(new Runnable() {
+                @Override
+                public void run() {
+                    selectValueDelayed(value, iteration+1);//we rise iteration for loop protection
+                }
+            }, 100);//maybe MhorizontalScrollView will be initialized faster than 400ms?
+        }
     }
 
     /**

--- a/ruler-picker/src/main/java/com/kevalpatel2106/rulerpicker/RulerView.java
+++ b/ruler-picker/src/main/java/com/kevalpatel2106/rulerpicker/RulerView.java
@@ -221,7 +221,7 @@ final class RulerView extends View {
 
                 if (a.hasValue(R.styleable.RulerView_indicator_interval)) {
                     mIndicatorInterval = a.getDimensionPixelSize(R.styleable.RulerView_indicator_interval,
-                            4);
+                            14);
                 }
 
                 if (a.hasValue(R.styleable.RulerView_long_height_height_ratio)) {
@@ -274,7 +274,7 @@ final class RulerView extends View {
     @Override
     protected void onDraw(Canvas canvas) {
         //Iterate through all value
-        for (int value = 1; value < mMaxValue - mMinValue; value++) {
+        for (int value = 1; value <= mMaxValue - mMinValue; value++) {
 
             if (value % mLongIndicatorStep == 0) {
                 drawLongIndicator(canvas, value);
@@ -284,11 +284,21 @@ final class RulerView extends View {
             }
         }
 
-        //Draw the first indicator.
-        drawSmallIndicator(canvas, 0);
+        if (mLongIndicatorStep != 1) {//because 1 means that we want every step marked with labels
+            //Draw the first indicator.
+            drawSmallIndicator(canvas, 0);
 
-        //Draw the last indicator.
-        drawSmallIndicator(canvas, getWidth());
+            //Draw the last indicator.
+            drawSmallIndicator(canvas, getWidth());
+        }{
+            //Draw the first indicator as long
+            drawLongIndicator(canvas, 0);
+            drawValueText(canvas, 0);
+
+            //Draw the last indicator as long
+            drawLongIndicator(canvas, getWidth());
+            drawValueText(canvas, getWidth());
+        }
         super.onDraw(canvas);
     }
 
@@ -296,7 +306,7 @@ final class RulerView extends View {
     protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
         //Measure dimensions
         mViewHeight = MeasureSpec.getSize(heightMeasureSpec);
-        int viewWidth = (mMaxValue - mMinValue - 1) * mIndicatorInterval;
+        int viewWidth = (mMaxValue - mMinValue + 2) * mIndicatorInterval;//+2 are artificially added to have more space for first and last indicator drawValueText()
 
         updateIndicatorHeight(mLongIndicatorHeightRatio, mShortIndicatorHeightRatio);
 
@@ -324,9 +334,9 @@ final class RulerView extends View {
      */
     private void drawSmallIndicator(@NonNull final Canvas canvas,
                                     final int value) {
-        canvas.drawLine(mIndicatorInterval * value,
+        canvas.drawLine(mIndicatorInterval * (value+1),//extra 1 for spacing which we artificially added in case the labels may wanna get drawn
                 0,
-                mIndicatorInterval * value,
+                mIndicatorInterval * (value+1),//extra 1 for spacing which we artificially added in case the labels may wanna get drawn
                 mShortIndicatorHeight,
                 mIndicatorPaint);
     }
@@ -339,9 +349,9 @@ final class RulerView extends View {
      */
     private void drawLongIndicator(@NonNull final Canvas canvas,
                                    final int value) {
-        canvas.drawLine(mIndicatorInterval * value,
+        canvas.drawLine(mIndicatorInterval * (value+1),//extra 1 for spacing which we artificially added in case the labels may wanna get drawn
                 0,
-                mIndicatorInterval * value,
+                mIndicatorInterval * (value+1),//extra 1 for spacing which we artificially added in case the labels may wanna get drawn
                 mLongIndicatorHeight,
                 mIndicatorPaint);
     }
@@ -356,7 +366,7 @@ final class RulerView extends View {
     private void drawValueText(@NonNull final Canvas canvas,
                                final int value) {
         canvas.drawText(String.valueOf(value + mMinValue),
-                mIndicatorInterval * value,
+                mIndicatorInterval * (value+1), //extra 1 for spacing which we artificially added in case the labels may wanna get drawn
                 mLongIndicatorHeight + mTextPaint.getTextSize(),
                 mTextPaint);
     }
@@ -442,6 +452,23 @@ final class RulerView extends View {
         refreshPaint();
     }
 
+    /**
+     * Set a step for a long indictor to be drawn.
+     * Every step a long indicator will be drawn.
+     * @param step - Step in decimal
+     */
+    void setLongIndicatorStep(final int step){
+        mLongIndicatorStep = step;
+        refreshPaint();
+    }
+
+    /**
+     * @return Long indicator step
+     * @see #setLongIndicatorStep(int)
+     */
+    int getLongIndicatorStep(){
+        return mLongIndicatorStep;
+    }
 
     /**
      * @return Get the minimum value displayed on the ruler.

--- a/ruler-picker/src/main/java/com/kevalpatel2106/rulerpicker/RulerView.java
+++ b/ruler-picker/src/main/java/com/kevalpatel2106/rulerpicker/RulerView.java
@@ -27,6 +27,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.util.AttributeSet;
 import android.view.View;
+import android.widget.LinearLayout;
 
 /**
  * Created by Keval Patel on 28 Mar 2018.
@@ -306,11 +307,21 @@ final class RulerView extends View {
     protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
         //Measure dimensions
         mViewHeight = MeasureSpec.getSize(heightMeasureSpec);
+
         int viewWidth = (mMaxValue - mMinValue + 2) * mIndicatorInterval;//+2 are artificially added to have more space for first and last indicator drawValueText()
 
         updateIndicatorHeight(mLongIndicatorHeightRatio, mShortIndicatorHeightRatio);
 
         this.setMeasuredDimension(viewWidth, mViewHeight);
+    }
+
+    /**
+     * Method that will trigger onMeasure to be recalled so that the view Width could be recalculated
+     */
+    public void triggerOnMeasure(){
+        LinearLayout.LayoutParams params = (LinearLayout.LayoutParams) this.getLayoutParams();
+        //params.width = mRulerView.calculateWidth();//would be usefull if onMeasure wouldn't get called
+        this.setLayoutParams(params);
     }
 
     /**

--- a/ruler-picker/src/main/java/com/kevalpatel2106/rulerpicker/RulerView.java
+++ b/ruler-picker/src/main/java/com/kevalpatel2106/rulerpicker/RulerView.java
@@ -126,6 +126,11 @@ final class RulerView extends View {
     private int mShortIndicatorHeight = 0;
 
     /**
+     * Allows to customise the step of the long indicator
+     */
+    private int mLongIndicatorStep = 5 /* Default value */;
+
+    /**
      * Integer color of the text, that is displayed on the ruler.
      *
      * @see #setTextColor(int)
@@ -236,6 +241,11 @@ final class RulerView extends View {
                     mMaxValue = a.getInteger(R.styleable.RulerView_max_value, 100);
                 }
                 setValueRange(mMinValue, mMaxValue);
+                if (a.hasValue(R.styleable.RulerValuePicker_long_indicator_step)){
+                    mLongIndicatorStep = a.getInteger(R.styleable.RulerValuePicker_long_indicator_step, 5);
+                    if (mLongIndicatorStep < 1)
+                        mLongIndicatorStep = 5; /*Fallback to default to prevent unexpected behaviour*/
+                }
             } finally {
                 a.recycle();
             }
@@ -266,7 +276,7 @@ final class RulerView extends View {
         //Iterate through all value
         for (int value = 1; value < mMaxValue - mMinValue; value++) {
 
-            if (value % 5 == 0) {
+            if (value % mLongIndicatorStep == 0) {
                 drawLongIndicator(canvas, value);
                 drawValueText(canvas, value);
             } else {

--- a/ruler-picker/src/main/res/values/attr.xml
+++ b/ruler-picker/src/main/res/values/attr.xml
@@ -26,6 +26,8 @@
     <attr name="indicator_color" format="color" />
     <attr name="indicator_width" format="dimension" />
 
+    <attr name="long_indicator_step" format="integer" />
+
     <attr name="notch_color" format="color" />
 
     <declare-styleable name="RulerView">
@@ -41,6 +43,8 @@
         <attr name="indicator_interval" />
         <attr name="indicator_color" />
         <attr name="indicator_width" />
+
+        <attr name="long_indicator_step" />
     </declare-styleable>
 
     <declare-styleable name="RulerValuePicker">
@@ -57,6 +61,8 @@
         <attr name="indicator_interval" />
         <attr name="indicator_color" />
         <attr name="indicator_width" />
+
+        <attr name="long_indicator_step" />
 
         <!-- Color of the top notch -->
         <attr name="notch_color" />


### PR DESCRIPTION
Posibility to define a long indicator step (for example setting to 1 will display all values).

Minor bug fixes:
* a defined Max value was never in the ruler and was impossible to reach
* a default parsed mIndicatorInterval was incorectly set to 4 instead of 14

Extra added:
*padding to a ruler beggining and ending of getIndicatorIntervalWidth() size to both sides for some space in case we will be drawing a text (in future spaces should be dynamically calculated if bigger needs rise up).
*methods for manipulating long interval step: getLongIndicatorStep() and setLongIndicatorStep(final int step)